### PR TITLE
do not set rownames in reformat_sigGenes; set in make_enrichRes instead

### DIFF
--- a/R/make_enrichRes.R
+++ b/R/make_enrichRes.R
@@ -35,6 +35,9 @@ make_enrichRes <- function(my.cpInput, interestCategory, ontology = "BP", pval_c
 
   res_df = my.cpInput[my.cpInput$interest.category==interestCategory & my.cpInput$go.category==ontology,]
 
+  # add rownames (required for enrichRes object)
+  row.names(res_df) <- res_df$Description
+
   # make vector out of geneIDs (actually geneNames) for gene universe
   geneNames = unlist(stringr::str_split(res_df$geneID, pattern = "/"), use.names = FALSE)
 

--- a/R/reformat_sigGenes.R
+++ b/R/reformat_sigGenes.R
@@ -48,7 +48,7 @@ reformat_sigGenes <- function(my.sigGenes){
   # add column for qvalue
   my.cpInput$qvalue <- qvalue::qvalue(my.cpInput$pvalue, fdr.level = NULL, lambda = 0)$qvalues
   # add rownames
-  rownames(my.cpInput) <- my.cpInput$ID
-
+#  rownames(my.cpInput) <- my.cpInput$ID
+   # do not set rownames here to avoid problems with duplicate GO terms (same term can be significant in multiple enrichments, so will have multiple rows with same GO ID and same term name, which will cause problems if set as rownames). Instead, can set rownames in make_enrichRes function.
   my.cpInput
 }


### PR DESCRIPTION
Fixes issue causing reformat_sigGenes function to throw an error if you have the same term enriched in multiple categories of interest.